### PR TITLE
Fixed SSL SMTP not working

### DIFF
--- a/app/models/Mailer.php
+++ b/app/models/Mailer.php
@@ -7,10 +7,20 @@ class Mailer extends CI_Model
 		$this->load->model('smtp');
 		$this->load->library('email');
 
+		// SMTP init
+		$email['protocol'] = 'smtp';
 		$email['smtp_host'] = $this->smtp->get_hostname();
+		// Remove this line if you are not using a secured SMTP server, otherwise it will not work
+		$email['smtp_crypto'] = 'ssl';
+
+		// SMTP Login
 		$email['smtp_user'] = $this->smtp->get_username();
 		$email['smtp_pass'] = $this->smtp->get_password();
 		$email['smtp_port'] = $this->smtp->get_port();
+		
+		// Added support for HTML mail
+		$email['mailtype'] = 'html';
+		$email['charset'] = 'utf-8';
 
 		$this->email->initialize($email);
 	}


### PR DESCRIPTION
Several users have complained that SMTP is not working. I asked around and found out that it doesn't work if the SMTP server uses an SSL certificate. So I adapted the code so that it would work, given that nowadays almost all servers use SSL.

Ideally, I'd like to be able to choose the connection mode directly from the administrator interface, but I don't have much time at the moment.